### PR TITLE
Add Macro Expansion in Preprocess Stage and Various Fixes

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -2,6 +2,7 @@
 # Declare DNA Files
 
 set(DNA_TYPEDEF_HEADERS
+	${CMAKE_SOURCE_DIR}/source/rose/makedna/DNA_ID.h
 	${CMAKE_SOURCE_DIR}/source/rose/makedna/DNA_listbase.h
 )
 

--- a/source/rose/makedna/DNA_ID.h
+++ b/source/rose/makedna/DNA_ID.h
@@ -1,0 +1,65 @@
+#ifndef DNA_ID_H
+#define DNA_ID_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* -------------------------------------------------------------------- */
+/** \name Data Structures
+ * \{ */
+
+/**
+ * ID structures represent generic data-blocks that are used by Rose. They are the base structure
+ * of all major data-blocks!
+ *
+ * All ID data-blocks are either internal to Rose and stored in the global main database,
+ * or belong to an external library. External library data-blocks are tagged as `LIB_TAG_EXTERN`,
+ * indicating a weak reference to that data.
+ *
+ * Weak references imply that the data may not be available after a restart,
+ * since the external library file might be missing, deleted, or altered,
+ * leading to broken references.
+ *
+ * ID structures can also define properties, which are mainly used by higher-level users to extend
+ * functionality (e.g., adding new variables or custom extensions).
+ */
+typedef struct ID {
+	/**
+	 * This is the base structure for other data-blocks, so we cannot define a specific type here!
+	 * The `prev` and `next` pointers enable this structure to be part of a linked list of data-blocks.
+	 */
+	void *prev, *next;
+
+	int flag;
+	int tag;
+
+	/** The first two bytes of the name are always used to determine the type of the ID. */
+	char name[66];
+
+	/** Pointer to additional properties, used for extended features. */
+	struct IDProperty *properties;
+
+	/**
+	 * The library this data-block was loaded from. If NULL, the data-block is internal to the program
+	 * (i.e., not loaded from an external library). This helps distinguish between internal and external
+	 * data-blocks.
+	 */
+	struct Library *lib;
+} ID;
+
+#ifdef __BIG_ENDIAN__
+/* Big Endian */
+#	define MAKE_ID2(a, b) ((a) << 8 | (b))
+#else
+/* Little Endian */
+#	define MAKE_ID2(a, b) ((b) << 8 | (a))
+#endif
+
+/** \} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // DNA_ID_H

--- a/source/rose/makedna/intern/makedna.c
+++ b/source/rose/makedna/intern/makedna.c
@@ -97,7 +97,7 @@ ROSE_INLINE bool fmake(const char *path) {
 	}
 
 	fprintf(handle, "/* Do not edit manually, changes will be overwritten. */\n");
-	
+
 	fclose(handle);
 	return true;
 }

--- a/source/rose/rosekernel/KER_lib_id.h
+++ b/source/rose/rosekernel/KER_lib_id.h
@@ -1,6 +1,8 @@
 #ifndef KER_LIB_ID_H
 #define KER_LIB_ID_H
 
+#include "DNA_ID.h"
+
 #include "LIB_sys_types.h"
 
 #ifdef __cplusplus
@@ -10,59 +12,6 @@ extern "C" {
 struct ID;
 struct IDProperty;
 struct Library;
-
-/* -------------------------------------------------------------------- */
-/** \name Data Structures
- * \{ */
-
-/**
- * ID structures represent generic data-blocks that are used by Rose. They are the base structure
- * of all major data-blocks!
- *
- * All ID data-blocks are either internal to Rose and stored in the global main database,
- * or belong to an external library. External library data-blocks are tagged as `LIB_TAG_EXTERN`,
- * indicating a weak reference to that data.
- *
- * Weak references imply that the data may not be available after a restart,
- * since the external library file might be missing, deleted, or altered,
- * leading to broken references.
- *
- * ID structures can also define properties, which are mainly used by higher-level users to extend
- * functionality (e.g., adding new variables or custom extensions).
- */
-typedef struct ID {
-	/**
-	 * This is the base structure for other data-blocks, so we cannot define a specific type here!
-	 * The `prev` and `next` pointers enable this structure to be part of a linked list of data-blocks.
-	 */
-	void *prev, *next;
-
-	int flag;
-	int tag;
-
-	/** The first two bytes of the name are always used to determine the type of the ID. */
-	char name[66];
-
-	/** Pointer to additional properties, used for extended features. */
-	struct IDProperty *properties;
-
-	/**
-	 * The library this data-block was loaded from. If NULL, the data-block is internal to the program
-	 * (i.e., not loaded from an external library). This helps distinguish between internal and external
-	 * data-blocks.
-	 */
-	struct Library *lib;
-} ID;
-
-#ifdef __BIG_ENDIAN__
-/* Big Endian */
-#	define MAKE_ID2(a, b) ((a) << 8 | (b))
-#else
-/* Little Endian */
-#	define MAKE_ID2(a, b) ((b) << 8 | (a))
-#endif
-
-/** \} */
 
 /* -------------------------------------------------------------------- */
 /** \name Datablock Creation

--- a/source/rose/translator/intern/ast/node.h
+++ b/source/rose/translator/intern/ast/node.h
@@ -113,7 +113,7 @@ const struct RCCScope *RT_node_block_scope(const struct RCCNode *node);
 /** \name Object Nodes
  * \{ */
 
-const struct RCCObject *RT_node_obj(const struct RCCNode *node);
+const struct RCCObject *RT_node_object(const struct RCCNode *node);
 
 /** \} */
 

--- a/source/rose/translator/intern/ast/node/object.c
+++ b/source/rose/translator/intern/ast/node/object.c
@@ -44,7 +44,7 @@ RCCNode *RT_node_new_function(RCContext *C, const RCCObject *object) {
 /** \name Object Node Utils
  * \{ */
 
-const struct RCCObject *RT_node_obj(const struct RCCNode *node) {
+const struct RCCObject *RT_node_object(const struct RCCNode *node) {
 	ROSE_assert(node->kind == NODE_OBJECT);
 
 	return ((const struct RCCNodeObject *)node)->object;

--- a/source/rose/translator/intern/parser.c
+++ b/source/rose/translator/intern/parser.c
@@ -1129,7 +1129,7 @@ const RCCType *RT_parser_struct(RCCParser *P, RCCToken **rest, RCCToken *token) 
 
 			const RCCType *now = field->type;
 			if (now->kind == TP_ARRAY) {
-				if (!ELEM(now->tp_array.boundary, ARRAY_VLA, ARRAY_VLA_STATIC)) {
+				if (ELEM(now->tp_array.boundary, ARRAY_VLA, ARRAY_VLA_STATIC)) {
 					ERROR(P, field->identifier, "vla arrays are not allowed within a struct");
 					return NULL;
 				}

--- a/source/rose/translator/intern/preprocessor.c
+++ b/source/rose/translator/intern/preprocessor.c
@@ -46,6 +46,40 @@ ROSE_INLINE void pop_conditional(RCCConditionalInclude **conditional) {
 /** \} */
 
 /* -------------------------------------------------------------------- */
+/** \name Macro
+ * \{ */
+
+typedef struct RCCMacroParameter {
+	struct RCCMacroParameter *prev, *next;
+
+	RCCToken *token;
+} RCCMacroParameter;
+
+ROSE_INLINE RCCMacroParameter *make_param(RCContext *C, RCCToken *token) {
+	RCCMacroParameter *p = RT_context_calloc(C, sizeof(RCCMacroParameter));
+
+	p->token = token;
+
+	return p;
+}
+
+typedef struct RCCMacro {
+	RCCToken *token;
+
+	enum {
+		MACRO_NORMAL,
+		MACRO_FNLIKE,
+	} kind;
+
+	bool user;
+
+	ListBase parameters;
+	ListBase body;
+} RCCMacro;
+
+/** \} */
+
+/* -------------------------------------------------------------------- */
 /** \name Data Structures
  * \{ */
 
@@ -103,33 +137,112 @@ ROSE_INLINE RCCToken *next_line(RCCToken *token) {
 	}
 	return token;
 }
-ROSE_INLINE RCCToken *copy_line(RCContext *C, RCCToken *token) {
-	RCCToken *head = NULL, *iter = NULL;
-	
+ROSE_INLINE RCCToken *copy_line(RCContext *C, ListBase *line, RCCToken *token) {
 	while(token->kind != TOK_EOF && (token->beginning_of_line == false || is(token->prev, "\\"))) {
 		if(!is(token, "\\") || token->next->beginning_of_line == false) {
-			RCCToken *copy = RT_token_duplicate(C, token);
-			
-			copy->prev = iter;
-			copy->next = NULL;
-			
-			if(!head) {
-				head = copy;
-			}
-			
-			iter = copy;
+			LIB_addtail(line, RT_token_duplicate(C, token));
 		}
 		token = token->next;
 	}
+	LIB_addtail(line, RT_token_new_eof(C));
+	return token;
+}
+ROSE_INLINE RCCMacro *macro_find(RCCPreprocessor *P, RCCToken *token) {
+	if (!RT_token_is_identifier(token)) {
+		return NULL;
+	}
+	return LIB_ghash_lookup(P->defines, RT_token_as_string(token));
+}
+
+bool RT_macro_expand(RCCPreprocessor *P, ListBase *tokens, RCCToken **prest, RCCToken *ptoken);
+
+void RT_macro_append(RCCPreprocessor *P, ListBase *tokens, RCCToken *source) {
+	for(RCCToken *itr = source; itr; itr = itr->next) {
+		if (!RT_macro_expand(P, tokens, &itr, itr)) {
+			RCCToken *now = RT_token_duplicate(P->context, itr);
+		
+			LIB_addtail(tokens, now);
+		}
+	}
+}
+
+/** real-rest, real-token, preprocessor-rest, preprocessor-token */
+bool RT_macro_expand(RCCPreprocessor *P, ListBase *tokens, RCCToken **prest, RCCToken *ptoken) {
+	RCCMacro *macro = macro_find(P, ptoken);
+	if(!macro) {
+		return false;
+	}
+	if(macro->user) {
+		// This macro is already beeing expanded, ignore this!
+		return false;
+	}
 	
-	if (iter) {
-		iter->next = RT_token_new_eof(C);
+	if((macro->kind == MACRO_FNLIKE) && !is(ptoken->next, "(")) {
+		// We have a function-like macro but it is not followed by an argument list, treat it as an identifier.
+		return false;
+	}
+	
+	ptoken = ptoken->next;
+	
+	macro->user = true;
+	
+	if(macro->kind == MACRO_NORMAL) {
+		RT_macro_append(P, tokens, (RCCToken *)macro->body.first);
+
+		*prest = ptoken;
 	}
 	else {
-		head = RT_token_new_eof(C);
+		if(!skip(P, &ptoken, ptoken, "(")) {
+			ROSE_assert_unreachable();
+		}
+		
+		RCCToken *params[64] = { NULL };
+		
+		size_t total;
+		for (total = 0; !consume(&ptoken, ptoken, ")"); total++) {
+			// Extra parameters get to keep the comma, so that we can copy it when parsing `__VA_ARG__`
+			if (0 < total && total <= LIB_listbase_count(&macro->parameters)) {
+				if(!skip(P, &ptoken, ptoken, ",")) {
+					break;
+				}
+			}
+			
+			params[total] = ptoken;
+			ptoken = ptoken->next;
+		}
+		*prest = ptoken;
+		
+		size_t nedeed = LIB_listbase_count(&macro->parameters);
+
+		if (total < nedeed) {
+			ERROR(P, ptoken, "too few arguments in function like macro");
+		}
+		else {
+			for (RCCToken *token = (RCCToken *)macro->body.first; token; token = token->next) {
+				size_t index = 0;
+				LISTBASE_FOREACH_INDEX(RCCMacroParameter *, parameter, &macro->parameters, index) {
+					if (RT_token_match(parameter->token, token)) {
+						break;
+					}
+				}
+
+				if (index < nedeed) {
+					LIB_addtail(tokens, RT_token_duplicate(P->context, params[index]));
+				}
+				else if (is(token, "__VA_ARG__")) {
+					while (index < total) {
+						LIB_addtail(tokens, RT_token_duplicate(P->context, params[index++]));
+					}
+				}
+				else if (!RT_macro_expand(P, tokens, &token, token)) {
+					LIB_addtail(tokens, RT_token_duplicate(P->context, token));
+				}
+			}
+		}
 	}
 	
-	return head;
+	macro->user = false;
+	return true;
 }
 
 ROSE_INLINE void macro_undef(RCCPreprocessor *P, RCCToken *token) {
@@ -150,20 +263,44 @@ ROSE_INLINE void macro_dodef(RCCPreprocessor *P, RCCToken **rest, RCCToken *toke
 	
 	// Function like macro
 	if(token->has_leading_space == false && is(token, "(")) {
-		ROSE_assert_unreachable();
+		RCCMacro *macro = RT_context_calloc(P->context, sizeof(RCCMacro));
+
+		macro->kind = MACRO_FNLIKE;
+		macro->token = identifier;
+
+		if (!skip(P, &token, token, "(")) {
+			ROSE_assert_unreachable();
+		}
+
+		for (int index = 0; !consume(&token, token, ")"); index++) {
+			if (index > 0) {
+				if (!skip(P, &token, token, ",")) {
+					break;
+				}
+			}
+
+			if (!is(token, "...")) {
+				LIB_addtail(&macro->parameters, make_param(P->context, token));
+			}
+			token = token->next;
+		}
+
+		*rest = copy_line(P->context, &macro->body, token);
+
+		// NOTE if we define something again, with the same name, the previous one is overriden!
+		LIB_ghash_insert(P->defines, (void *)RT_token_as_string(identifier), macro);
 	}
 	else {
-		LIB_ghash_insert(P->defines, (void *)RT_token_as_string(identifier), copy_line(P->context, token));
-	}
-	
-	*rest = next_line(identifier);
-}
+		RCCMacro *macro = RT_context_calloc(P->context, sizeof(RCCMacro));
+		
+		macro->kind = MACRO_NORMAL;
+		macro->token = identifier;
 
-ROSE_INLINE void *macro_find(RCCPreprocessor *P, RCCToken *token) {
-	if (!RT_token_is_identifier(token)) {
-		return NULL;
+		*rest = copy_line(P->context, &macro->body, token);
+		
+		// NOTE if we define something again, with the same name, the previous one is overriden!
+		LIB_ghash_insert(P->defines, (void *)RT_token_as_string(identifier), macro);
 	}
-	return LIB_ghash_lookup(P->defines, RT_token_as_string(token));
 }
 
 RCCToken *skip_conditional_nested(RCCPreprocessor *P, RCCToken *token) {
@@ -205,30 +342,19 @@ void RCC_preprocessor_do(RCContext *context, const RCCFile *file, ListBase *toke
 	preprocessor->conditional = NULL;
 	preprocessor->defines = LIB_ghash_str_new("RCCPreprocessor::defines");
 	
-	RCCToken *head = (RCCToken *)NULL;
-	RCCToken *curr = (RCCToken *)NULL;
-
 	RCCToken *itr = (RCCToken *)tokens->first;
+
+	LIB_listbase_clear(tokens);
+
 	while(itr && itr->kind != TOK_EOF) {
-		if (macro_find(preprocessor, itr)) {
-			/**
-			 * Here we found a preprocessor macro that we need to expand!
-			 */
-			ROSE_assert_unreachable();
+		if (RT_macro_expand(preprocessor, tokens, &itr, itr)) {
 			continue;
 		}
 
 		if(!directive(itr)) {
-			if (curr) {
-				itr->prev = curr;
-				curr->next = itr;
-				curr = itr;
-			}
-			else {
-				itr->prev = NULL;
-				head = curr = itr;
-			}
-			itr = itr->next;
+			RCCToken *next = itr->next;
+			LIB_addtail(tokens, itr);
+			itr = next;
 			continue;
 		}
 		
@@ -278,6 +404,22 @@ void RCC_preprocessor_do(RCContext *context, const RCCFile *file, ListBase *toke
 			}
 			continue;
 		}
+		if (is(itr, "else")) {
+			if (!preprocessor->conditional || preprocessor->conditional->kind == IN_ELSE) {
+				ERROR(preprocessor, itr, "stray #else");
+				itr = next_line(itr);
+				break;
+			}
+
+			preprocessor->conditional->kind = IN_ELSE;
+
+			itr = next_line(itr);
+
+			if (preprocessor->conditional->included) {
+				itr = skip_conditional(preprocessor, itr);
+			}
+			continue;
+		}
 		if (is(itr, "endif")) {
 			if (!preprocessor->conditional) {
 				ERROR(preprocessor, itr->next, "stray #elif");
@@ -305,18 +447,9 @@ void RCC_preprocessor_do(RCContext *context, const RCCFile *file, ListBase *toke
 		ERROR(preprocessor, itr, "invalid preprocessor directive");
 		itr = next_line(itr->next);
 	}
-
-	if (curr) {
-		curr = curr->next = itr;
-	}
-	else {
-		head = itr;
-	}
+	LIB_addtail(tokens, itr);
 	
 	LIB_ghash_free(preprocessor->defines, NULL, NULL);
-	
-	tokens->first = (struct Link *)head;
-	tokens->last = (struct Link *)itr;
 
 	MEM_freeN(preprocessor);
 }

--- a/source/rose/translator/intern/source.c
+++ b/source/rose/translator/intern/source.c
@@ -58,7 +58,13 @@ ROSE_INLINE void *fcache_content_molest(void *content, size_t *length) {
 		if ((ELEM(p[0], '\n') && ELEM(p[1], '\r')) || (ELEM(p[0], '\r') && ELEM(p[1], '\n'))) {
 			p[0] = ' ';
 			p[1] = '\n';
+			continue;
 		}
+		if ((ELEM(p[0], '\t'))) {
+			p[0] = ' ';
+			continue;
+		}
+
 	}
 	return content;
 }
@@ -162,12 +168,12 @@ void RT_file_free(RCCFile *file) {
 
 void RT_source_error(const RCCFile *file, const RCCSLoc *location, const char *fmt, ...) {
 	const char *input = file ? RT_file_content(file) : NULL;
-	const char *begin = location->p;
+	const char *begin = (location->p) ? location->p : "unkown source";
 	while (input < begin && begin[-1] != '\n') {
 		begin--;
 	}
 
-	const char *end = location->p;
+	const char *end = (location->p) ? location->p : "unkown source";
 	while (*end != '\0' && *end != '\n') {
 		end++;
 	}

--- a/source/rose/translator/test/utils.cc
+++ b/source/rose/translator/test/utils.cc
@@ -188,10 +188,10 @@ TEST(Utils, Parser) {
 						RT_type_function_finalize(C, expected);
 					}
 				}
-				EXPECT_TRUE(RT_type_same(RT_node_obj(node)->type, expected));
-				EXPECT_TRUE(RT_token_match(RT_node_obj(node)->identifier, RT_token_new_name(C, "main")));
+				EXPECT_TRUE(RT_type_same(RT_node_object(node)->type, expected));
+				EXPECT_TRUE(RT_token_match(RT_node_object(node)->identifier, RT_token_new_name(C, "main")));
 				{
-					const RCCNode *stmt = RT_node_block_first(RT_node_obj(node)->body);
+					const RCCNode *stmt = RT_node_block_first(RT_node_object(node)->body);
 					{
 						EXPECT_EQ(stmt->kind, NODE_UNARY);
 						EXPECT_EQ(stmt->type, UNARY_RETURN);
@@ -248,7 +248,7 @@ TEST(Utils, ParserTypedef) {
 						RT_type_struct_finalize(something);
 					}
 				}
-				EXPECT_TRUE(RT_type_same(RT_node_obj(node)->type, something));
+				EXPECT_TRUE(RT_type_same(RT_node_object(node)->type, something));
 				node = node->next;
 			}
 			RCCType *different = NULL;
@@ -267,7 +267,7 @@ TEST(Utils, ParserTypedef) {
 						RT_type_struct_finalize(different);
 					}
 				}
-				EXPECT_TRUE(RT_type_same(RT_node_obj(node)->type, different));
+				EXPECT_TRUE(RT_type_same(RT_node_object(node)->type, different));
 				node = node->next;
 			}
 			EXPECT_EQ(node, nullptr);


### PR DESCRIPTION
## 1. [New] Macro Expansion During Preprocessing

Added macro expansion during the preprocessing state of the compilation process. This allows for better code transformation and ensures that macros are properly expanded before further compilation stages.

## 2. [Fix] Error Printing Fixes Around Tabs

Fixed an issue where error messages were not being printed correctly when tabs were involved. This ensures that error messages now accurately reflect the code's layout, improving debugging clarity.

## 3. [Fix] Improved Array Interpretation in Struct Types

Corrected the handling of array interpretation within struct types, which ensures that arrays in structures are processed and accessed correctly during compilation.

## 4. [Fix] Renamed Functions for Better Readability

Some function names have been updated to make the codebase more readable and maintainable. These changes should improve code clarity and help future developers navigate the code.